### PR TITLE
Update main.tf

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -22,7 +22,11 @@ module "vpc" {
   name    = "scoutflo-vpc-${random_string.suffix.result}"
   cidr    = "10.0.0.0/16"
   azs     = slice(data.aws_availability_zones.available.names, 0, min(3, length(data.aws_availability_zones.available.names)))
-  public_subnets = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
+  public_subnets = slice(
+    ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"],
+    0,
+    min(3, length(data.aws_availability_zones.available.names))
+  )
   enable_dns_hostnames = true
   public_subnet_tags = {
     "kubernetes.io/cluster/your_cluster_name" = "shared"


### PR DESCRIPTION
Added a new logic for azs to pick either "3" or the minimum number of available az on the selected region.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted availability-zone selection to use up to three zones while adapting when fewer are available.
  * Aligned public subnet selection with available zones to prevent mismatches and deployment failures, improving stability and compatibility across regions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->