### PR TITLE
Update main.tf

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -30,7 +30,7 @@ module "vpc" {
   enable_dns_hostnames = true
   public_subnet_tags = {
     "kubernetes.io/cluster/your_cluster_name" = "shared"
-    "kubernetes.io/role/elb"                  = 1
+    "kubernetes.io/role/elb"                  = "1"
   }
   tags = {
     "scoutflo-terraform" = "true"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized the kubernetes.io/role/elb subnet tag value from numeric 1 to string "1" to unify tag typing across environments.
  * This change may affect systems that read or filter by this tag (e.g., reporting, discovery, or automation relying on exact value types). Review any tag-based rules or dashboards to ensure they continue to match the updated string value. No functional behavior changes or downtimes are expected from this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->